### PR TITLE
fixed invalid search endpoint

### DIFF
--- a/src/main/java/com/facebook/ads/sdk/AdAccount.java
+++ b/src/main/java/com/facebook/ads/sdk/AdAccount.java
@@ -1,4 +1,4 @@
-F/**
+/**
  * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
  *
  * You are hereby granted a non-exclusive, worldwide, royalty-free license to

--- a/src/main/java/com/facebook/ads/sdk/AdAccount.java
+++ b/src/main/java/com/facebook/ads/sdk/AdAccount.java
@@ -1,4 +1,4 @@
-/**
+F/**
  * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
  *
  * You are hereby granted a non-exclusive, worldwide, royalty-free license to
@@ -11318,7 +11318,7 @@ public class AdAccount extends APINode {
     }
 
     public APIRequestGetTargetingSearch(String nodeId, APIContext context) {
-      super(context, nodeId, "/targetingsearch", "GET", Arrays.asList(PARAMS));
+      super(context, nodeId, "/search", "GET", Arrays.asList(PARAMS));
     }
 
     @Override


### PR DESCRIPTION
I think there is an error with that searching endpoint. Using /targetingsearch leads to error message:

```
   "error": {
      "message": "Unsupported get request. Please read the Graph API documentation at https://developers.facebook.com/docs/graph-api",
      "type": "GraphMethodException",
      "code": 100,
      "fbtrace_id": "xxxxxxxxx"
   }
}
```
